### PR TITLE
Word document labelling

### DIFF
--- a/R/apply_sensitivity_label.R
+++ b/R/apply_sensitivity_label.R
@@ -8,9 +8,9 @@
 }
 
 #' Read Sensitivity Label
-#' @description Reads the sensitivity label from an Excel file using openxlsx2::wb_get_mips. Returns the label name, 'no label' if none is found, or errors if unexpected.
+#' @description Reads the sensitivity label from an Excel or Word doc file. Returns the label name, 'no label' if none is found, or errors if unexpected.
 #'
-#' @param file Path to the Excel file (.xlsx or .xls)
+#' @param file Path to the Excel or Word file (.xlsx, .xls or .docx)
 #' @return The sensitivity label name, or 'no label' if none is found.
 #' @export
 read_sensitivity_label <- function(file) {
@@ -32,14 +32,28 @@ read_sensitivity_label <- function(file) {
     cli::cli_abort("File {.path {file}} does not exist.")
   }
 
-  # Check file is Excel workbook
+  # Check file is valid
   file_ext <- tolower(tools::file_ext(file))
-  if (!file_ext %in% c("xlsx", "xls")) {
-    cli::cli_abort("{.arg file} must be an Excel workbook with {.val .xlsx} or {.val .xls} extension, not {.val .{file_ext}}.")
+  if (!file_ext %in% c("xlsx", "xls", "docx")) {
+    cli::cli_abort("{.arg file} must be an Excel workbook or Word document with {.val .xlsx}, {.val .xls} or {.val .docx} extension, not {.val .{file_ext}}.")
   }
 
-  wb <- openxlsx2::wb_load(file)
-  mips <- openxlsx2::wb_get_mips(wb)
+  ## Extracting label within Excel workbooks ----
+
+  if(file_ext %in% c("xlsx", "xls")){
+
+    wb <- openxlsx2::wb_load(file)
+    mips <- openxlsx2::wb_get_mips(wb)
+
+  }
+
+  ## Extracting label within Word docs ----
+
+  if(file_ext == "docx"){
+
+    mips <- openxlsx2::read_xml(unzip(file,'docMetadata/LabelInfo.xml'))
+
+  }
 
   if (is.null(mips) || length(mips) == 0 || mips == "") {
     return("no label")
@@ -48,6 +62,7 @@ read_sensitivity_label <- function(file) {
   # Try to extract label name from XML
   xml_map <- .get_sensitivity_xml_map()
   label_name <- which(xml_map == mips) |> names()
+
 
   if (length(label_name) == 0) {
     cli::cli_abort("Unknown sensitivity label ID found in file {.path {file}}.")
@@ -58,11 +73,11 @@ read_sensitivity_label <- function(file) {
 
 
 #' Apply Sensitivity Label
-#' @description Applies a sensitivity label to an Excel file using openxlsx2 and built-in XML. Supported labels are 'Personal', 'OFFICIAL', and 'OFFICIAL_SENSITIVE_VMO' (visual markings only).
+#' @description Applies a sensitivity label to files using openxlsx2 and built-in XML. Supported labels are 'Personal', 'OFFICIAL', and 'OFFICIAL_SENSITIVE_VMO' (visual markings only).
 #'
 #' The function loads the Excel file, applies the specified sensitivity label using the appropriate XML, and saves the modified file. If successful, it silently returns the file path.
 #'
-#' @param file Path to the Excel file (.xlsx or .xls)
+#' @param file Path to the Excel or Word file (.xlsx, .xls, or .docs)
 #' @param label Sensitivity label. One of: 'Personal', 'OFFICIAL', 'OFFICIAL_SENSITIVE_VMO'.
 #' @return Silently returns the file path if successful.
 #' @export
@@ -105,18 +120,109 @@ apply_sensitivity_label <- function(file, label) {
     cli::cli_abort("File {.path {file}} does not exist.")
   }
 
-  # Check file is Excel workbook
+  # Check file is valid
   file_ext <- tolower(tools::file_ext(file))
-  if (!file_ext %in% c("xlsx", "xls")) {
-    cli::cli_abort("{.arg file} must be an Excel workbook with {.val .xlsx} or {.val .xls} extension, not {.val .{file_ext}}.")
+  if (!file_ext %in% c("xlsx", "xls", "docx")) {
+    cli::cli_abort("{.arg file} must be an Excel workbook or Word document with {.val .xlsx}, {.val .xls} or {.val .docx} extension, not {.val .{file_ext}}.")
   }
 
-  # Load workbook and apply label
-  wb <- openxlsx2::wb_load(file)
-  xml_map <- .get_sensitivity_xml_map()
-  xml <- xml_map[[label]]
-  wb <- openxlsx2::wb_add_mips(wb, xml)
-  openxlsx2::wb_save(wb, file)
+
+
+  ## Apply label to Excel workbooks ----
+
+  if(file_ext %in% c("xlsx", "xls")){
+
+    wb <- openxlsx2::wb_load(file)
+    xml_map <- .get_sensitivity_xml_map()
+    xml <- xml_map[[label]]
+    wb <- openxlsx2::wb_add_mips(wb, xml)
+    openxlsx2::wb_save(wb, file)
+
+  }
+
+  ## Apply label to Word docs ----
+
+  if(file_ext == "docx"){
+
+    # Parsing input
+    file_path <- dirname(path)
+    file_name <- basename(path)
+    file_type <- tools::file_ext(path)
+    # Removing file type from actual name
+    file_name <- sub(paste0(".", file_type), "", file_name)
+
+    # Zipping process needs its own directory
+    # We'll reset it using on.exit later
+    current_wd <- getwd()
+
+    zipdir <- paste0(file_path, "/", file_name)
+
+    # Create the dir using that name
+    dir.create(zipdir)
+
+    # Unzip the file into the dir
+    unzip(x, exdir= zipdir)
+
+    xml_map <- .get_sensitivity_xml_map()
+    xml <- xml_map[[label]]
+
+    # Create the dir using that name
+    dir.create(paste0(zipdir, "/docMetadata"))
+
+    # Write the XML data to the temp directory
+    write_xml(xml, paste0(zipdir, "/docMetadata/LabelInfo.xml"), useBytes = TRUE)
+
+    # Update content file with new child node
+    openxlsx2:::write_file(
+      head = "",
+      body = xml_add_child(
+        xml_node = paste0(zipdir, "/[Content_Types].xml"),
+        xml_child = '<Override PartName="/docMetadata/LabelInfo.xml" ContentType="application/vnd.ms-office.classificationlabels+xml"/>'
+      ),
+      tail = "",
+      fl = paste0(zipdir, "/[Content_Types].xml")
+    )
+
+    # Update .rels file with new child node
+    openxlsx2:::write_file(
+      head = "",
+      body = xml_add_child(
+        xml_node = paste0(zipdir, "/_rels/.rels"),
+        xml_child = '<Relationship Id="rId6" Type="http://schemas.microsoft.com/office/2020/02/relationships/classificationlabels" Target="docProps/custom.xml" />'
+      ),
+      tail = "",
+      fl = paste0(zipdir, "/_rels/.rels")
+    )
+
+    # Delete original file
+    file.remove(x)
+
+    newzip <- paste0(file_path, "/", file_name, ".zip")
+    file.create(newzip)
+
+    setwd(zipdir) # Setting new base directory to avoid needless recursion in file zipping
+    # will be reset on.exit() anyway so don't change.
+
+    suppressWarnings(
+      zip::zip(zipfile = newzip,
+               files = list.files(zipdir, all.files = TRUE, full.names = FALSE, recursive = TRUE, include.dirs = TRUE),
+               recurse = FALSE,
+               include_directories = FALSE,
+               root = ".") # end of zip()
+    ) # End of suppressWarnings
+
+    # Delete un-zipped files
+    file.remove(zipdir)
+
+    # Re-naming file
+    file.rename(from = newzip,
+                to = file)
+
+    # Keep this as last-evaluated function - keeps files stable
+    on.exit(setwd(current_wd))
+
+  }
+
 
   invisible(file)
 }

--- a/R/apply_sensitivity_label.R
+++ b/R/apply_sensitivity_label.R
@@ -73,7 +73,7 @@ read_sensitivity_label <- function(file) {
 #'
 #' The function loads the Excel file, applies the specified sensitivity label using the appropriate XML, and saves the modified file. If successful, it silently returns the file path.
 #'
-#' @param file Path to the Excel or Word file (.xlsx or .docx)
+#' @param file Path to the Excel or Word file (`.xlsx` or `.docx`)
 #' @param label Sensitivity label. One of: 'Personal', 'OFFICIAL', 'OFFICIAL_SENSITIVE_VMO'.
 #' @return Silently returns the file path if successful.
 #' @export

--- a/R/apply_sensitivity_label.R
+++ b/R/apply_sensitivity_label.R
@@ -77,7 +77,7 @@ read_sensitivity_label <- function(file) {
 #'
 #' The function loads the Excel file, applies the specified sensitivity label using the appropriate XML, and saves the modified file. If successful, it silently returns the file path.
 #'
-#' @param file Path to the Excel or Word file (.xlsx, .xls, or .doxs)
+#' @param file Path to the Excel or Word file (.xlsx, .xls, or .docx)
 #' @param label Sensitivity label. One of: 'Personal', 'OFFICIAL', 'OFFICIAL_SENSITIVE_VMO'.
 #' @return Silently returns the file path if successful.
 #' @export

--- a/R/apply_sensitivity_label.R
+++ b/R/apply_sensitivity_label.R
@@ -34,25 +34,21 @@ read_sensitivity_label <- function(file) {
 
   # Check file is valid
   file_ext <- tolower(tools::file_ext(file))
-  if (!file_ext %in% c("xlsx", "xls", "docx")) {
-    cli::cli_abort("{.arg file} must be an Excel workbook or Word document with {.val .xlsx}, {.val .xls} or {.val .docx} extension, not {.val .{file_ext}}.")
+  if (!file_ext %in% c("xlsx", "docx")) {
+    cli::cli_abort("{.arg file} must be an Excel workbook or Word document with {.val .xlsx} or {.val .docx} extension, not {.val .{file_ext}}.")
   }
 
   ## Extracting label within Excel workbooks ----
 
-  if(file_ext %in% c("xlsx", "xls")){
-
+  if(file_ext == "xlsx"){
     wb <- openxlsx2::wb_load(file)
     mips <- openxlsx2::wb_get_mips(wb)
-
   }
 
   ## Extracting label within Word docs ----
 
   if(file_ext == "docx"){
-
     mips <- openxlsx2::read_xml(unzip(file,'docMetadata/LabelInfo.xml'))
-
   }
 
   if (is.null(mips) || length(mips) == 0 || mips == "") {
@@ -77,7 +73,7 @@ read_sensitivity_label <- function(file) {
 #'
 #' The function loads the Excel file, applies the specified sensitivity label using the appropriate XML, and saves the modified file. If successful, it silently returns the file path.
 #'
-#' @param file Path to the Excel or Word file (.xlsx, .xls, or .docx)
+#' @param file Path to the Excel or Word file (.xlsx or .docx)
 #' @param label Sensitivity label. One of: 'Personal', 'OFFICIAL', 'OFFICIAL_SENSITIVE_VMO'.
 #' @return Silently returns the file path if successful.
 #' @export
@@ -122,28 +118,23 @@ apply_sensitivity_label <- function(file, label) {
 
   # Check file is valid
   file_ext <- tolower(tools::file_ext(file))
-  if (!file_ext %in% c("xlsx", "xls", "docx")) {
-    cli::cli_abort("{.arg file} must be an Excel workbook or Word document with {.val .xlsx}, {.val .xls} or {.val .docx} extension, not {.val .{file_ext}}.")
+  if (!file_ext %in% c("xlsx", "docx")) {
+    cli::cli_abort("{.arg file} must be an Excel workbook or Word document with {.val .xlsx} or {.val .docx} extension, not {.val .{file_ext}}.")
   }
-
-
 
   ## Apply label to Excel workbooks ----
 
-  if(file_ext %in% c("xlsx", "xls")){
-
+  if(file_ext == "xlsx"){
     wb <- openxlsx2::wb_load(file)
     xml_map <- .get_sensitivity_xml_map()
     xml <- xml_map[[label]]
     wb <- openxlsx2::wb_add_mips(wb, xml)
     openxlsx2::wb_save(wb, file)
-
   }
 
   ## Apply label to Word docs ----
 
   if(file_ext == "docx"){
-
     # Parsing input
     file_path <- dirname(file)
     file_name <- basename(file)
@@ -220,9 +211,6 @@ apply_sensitivity_label <- function(file, label) {
 
     # Keep this as last-evaluated function - keeps files stable
     on.exit(setwd(current_wd))
-
   }
-
-
   invisible(file)
 }

--- a/R/apply_sensitivity_label.R
+++ b/R/apply_sensitivity_label.R
@@ -145,9 +145,9 @@ apply_sensitivity_label <- function(file, label) {
   if(file_ext == "docx"){
 
     # Parsing input
-    file_path <- dirname(path)
-    file_name <- basename(path)
-    file_type <- tools::file_ext(path)
+    file_path <- dirname(file)
+    file_name <- basename(file)
+    file_type <- tools::file_ext(file)
     # Removing file type from actual name
     file_name <- sub(paste0(".", file_type), "", file_name)
 

--- a/R/apply_sensitivity_label.R
+++ b/R/apply_sensitivity_label.R
@@ -77,7 +77,7 @@ read_sensitivity_label <- function(file) {
 #'
 #' The function loads the Excel file, applies the specified sensitivity label using the appropriate XML, and saves the modified file. If successful, it silently returns the file path.
 #'
-#' @param file Path to the Excel or Word file (.xlsx, .xls, or .docs)
+#' @param file Path to the Excel or Word file (.xlsx, .xls, or .doxs)
 #' @param label Sensitivity label. One of: 'Personal', 'OFFICIAL', 'OFFICIAL_SENSITIVE_VMO'.
 #' @return Silently returns the file path if successful.
 #' @export

--- a/R/apply_sensitivity_label.R
+++ b/R/apply_sensitivity_label.R
@@ -212,7 +212,7 @@ apply_sensitivity_label <- function(file, label) {
     ) # End of suppressWarnings
 
     # Delete un-zipped files
-    file.remove(zipdir)
+    unlink(zipdir, recursive = TRUE)
 
     # Re-naming file
     file.rename(from = newzip,

--- a/R/apply_sensitivity_label.R
+++ b/R/apply_sensitivity_label.R
@@ -10,7 +10,7 @@
 #' Read Sensitivity Label
 #' @description Reads the sensitivity label from an Excel or Word doc file. Returns the label name, 'no label' if none is found, or errors if unexpected.
 #'
-#' @param file Path to the Excel or Word file (.xlsx, .xls or .docx)
+#' @param file Path to the Excel or Word file (`.xlsx` or `.docx`)
 #' @return The sensitivity label name, or 'no label' if none is found.
 #' @export
 read_sensitivity_label <- function(file) {

--- a/R/apply_sensitivity_label.R
+++ b/R/apply_sensitivity_label.R
@@ -161,7 +161,7 @@ apply_sensitivity_label <- function(file, label) {
     dir.create(zipdir)
 
     # Unzip the file into the dir
-    unzip(x, exdir= zipdir)
+    unzip(file, exdir= zipdir)
 
     xml_map <- .get_sensitivity_xml_map()
     xml <- xml_map[[label]]
@@ -195,7 +195,7 @@ apply_sensitivity_label <- function(file, label) {
     )
 
     # Delete original file
-    file.remove(x)
+    file.remove(file)
 
     newzip <- paste0(file_path, "/", file_name, ".zip")
     file.create(newzip)

--- a/R/apply_sensitivity_label.R
+++ b/R/apply_sensitivity_label.R
@@ -167,7 +167,7 @@ apply_sensitivity_label <- function(file, label) {
     xml <- xml_map[[label]]
 
     # Create the dir using that name
-    dir.create(paste0(zipdir, "/docMetadata"))
+    dir.create(paste0(zipdir, "/docMetadata"), showWarnings = FALSE, recursive = TRUE)
 
     # Write the XML data to the temp directory
     write_xml(xml, paste0(zipdir, "/docMetadata/LabelInfo.xml"), useBytes = TRUE)

--- a/R/apply_sensitivity_label.R
+++ b/R/apply_sensitivity_label.R
@@ -188,7 +188,7 @@ apply_sensitivity_label <- function(file, label) {
       head = "",
       body = xml_add_child(
         xml_node = paste0(zipdir, "/_rels/.rels"),
-        xml_child = '<Relationship Id="rId6" Type="http://schemas.microsoft.com/office/2020/02/relationships/classificationlabels" Target="docProps/custom.xml" />'
+        xml_child = '<Relationship Id="rId6" Type="http://schemas.microsoft.com/office/2020/02/relationships/classificationlabels" Target="docMetadata/LabelInfo.xml" />'
       ),
       tail = "",
       fl = paste0(zipdir, "/_rels/.rels")


### PR DESCRIPTION
Hi @Moohan, that's the functions updated for Word doc label assignment and extraction. Still needs thorough testing but it's almost identical to my original function which was (fairly) stable so fingers crossed.

## Summary by Sourcery

Extend sensitivity label assignment and extraction to support Word documents alongside Excel workbooks

New Features:
- Support reading sensitivity labels from Word (.docx) files by extracting LabelInfo.xml
- Support applying sensitivity labels to Word (.docx) files by injecting LabelInfo.xml and updating content types and relationships

Enhancements:
- Update file validation and Roxygen documentation to include Word document extensions (.docx)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added support for applying and reading sensitivity labels in Word (.docx) files alongside Excel (.xlsx/.xls); both formats report “no label” when none found and error on unmapped labels.
  - DOCX handling now applies labels correctly while preserving existing Excel behaviour; functions return invisibly on success.

- Documentation
  - Updated descriptions and parameter docs to cover Excel and Word inputs and clarified expected outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->